### PR TITLE
Volume mounts for Make and Cmake

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,6 @@
   "service": "dev",
   "workspaceFolder": "/workspace",
   "overrideCommand": true,
-  "postCreateCommand": "git config --global user.name \"${GIT_AUTHOR_NAME:-Your Name}\" && git config --global user.email \"${GIT_AUTHOR_EMAIL:-you@example.com}\" && /workspace/tools/setup-tools-envs.sh && /workspace/build.sh cmake",
+  "postCreateCommand": "git config --global user.name \"${GIT_AUTHOR_NAME:-Your Name}\" && git config --global user.email \"${GIT_AUTHOR_EMAIL:-you@example.com}\"",
   "shutdownAction": "stopCompose"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,10 @@ services:
     volumes:
       - ..:/workspace:cached
       - micromamba-data:/opt/micromamba
+      - workspace-build:/workspace/build
+      - workspace-cache:/workspace/.cache
     command: sleep infinity
 volumes:
   micromamba-data:
+  workspace-build:
+  workspace-cache:


### PR DESCRIPTION
# Description
The current dev container implementation had two main problems. Compiling the binary was extremely slow and it could potentially cause mounting and file permission issues. 

To fix these issues `build` and `.cache` are now volume mounts in the devcontainer environment. This gives docker full ownership of the folders and does not sync changes made in these folders to your local file system. The constant syncing increased compile time and caused docker to occasionally error. 

This pull request does not guarantee that no issues will arise with docker but is a step in the right direction to improving the dev experience on Apple Darwin. 

# Artifacts for PR #45 (DO NOT CHANGE)
- [Coverage Artifact](https://uwcubesat.github.io/found/45/merge/coverage)
- [Doxygen Artifact](https://uwcubesat.github.io/found/45/merge/doxygen)