### PR TITLE
Calculating covariance from CRA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(FLOAT_MODE)
 endif()
 
 # Debug config
-set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -fno-stack-protector -fno-omit-frame-pointer")
 
 # Release config
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")

--- a/src/common/style.hpp
+++ b/src/common/style.hpp
@@ -22,6 +22,14 @@ typedef std::vector<Vec2> Points;
 /// coordinate system.
 typedef Vec3 PositionVector;
 
+/// The output of a DistanceAndCovarianceDeterminationAlgorithm. Outputs a 3D
+/// Vector and its associated covariance matrix that represents the satellite's
+/// position.
+struct DistanceAndCovariance {
+    PositionVector distance;
+    Mat3 covariance;
+};
+
 /**
  * Represents an image
  * 

--- a/src/distance/distance.cpp
+++ b/src/distance/distance.cpp
@@ -51,6 +51,51 @@ PositionVector SpheroidDistanceDeterminationAlgorithm::Run(const Points &p) {
     return vecToEarth;
 }
 
+///// SpheroidDistanceAndCovarianceDeterminationAlgorithm /////
+
+DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(const Points &p) {
+    PositionVector vecToEarth = algorithm_->Run(p); // s_C
+
+    const Vec3 shapeMatrixFactor = algorithm_->getPrincipleAxes().cwiseInverse();
+    const Mat3 shapeMatrix = shapeMatrixFactor.cwiseProduct(shapeMatrixFactor).asDiagonal();
+    
+    // A_C
+    const Mat3 transformedShapeMatrix = algorithm_->getTPC() * shapeMatrix * algorithm_->getTPC().transpose();
+
+    // M_C
+    const Mat3 transformedConicLocusMatrix = transformedShapeMatrix * (vecToEarth * vecToEarth.transpose()) * transformedShapeMatrix - (vecToEarth.transpose() * transformedShapeMatrix * vecToEarth - 1.0) * transformedShapeMatrix;
+
+    // sigma_{u_i}
+    const decimal pixelStandardDeviation = 0.0; // TODO
+    // d_x
+    const decimal focalLengthPixels = 0.0; // TODO
+
+    Mat3 outCovarianceInverse = Mat3::Zero();
+
+    for (size_t i = 0; i < p.size(); i++) {
+        // p[i] = u_i
+        // x_i
+        const Vec3 &point = algorithm_->getCamera().PixelToImageCoordinates(p[i]);
+
+        // we can also calculate this by using the image plane points, we dont
+        // need to necessarily get it from the pixel coordinates
+        const decimal pointVariance = (pixelStandardDeviation / focalLengthPixels);
+        
+        // see Exercise 8.6
+        const Mat3 pointCovariance = Vec3(pointVariance, pointVariance, 0).asDiagonal();
+
+        const decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix * pointCovariance * transformedConicLocusMatrix * point;
+        const Mat3 jacobian = 2.0 * vecToEarth.transpose() * ((point.transpose() * transformedShapeMatrix * point) * transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * transformedShapeMatrix);
+
+        outCovarianceInverse += (jacobian.transpose() * jacobian) / residualVariance;
+    }
+
+    return {
+        vecToEarth,
+        outCovarianceInverse.inverse()
+    };
+}
+
 ///// SphericalDistanceDeterminationAlgorithm /////
 
 PositionVector SphericalDistanceDeterminationAlgorithm::Run(const Points &p) {

--- a/src/distance/distance.cpp
+++ b/src/distance/distance.cpp
@@ -54,6 +54,9 @@ PositionVector SpheroidDistanceDeterminationAlgorithm::Run(const Points &p) {
 ///// SpheroidDistanceAndCovarianceDeterminationAlgorithm /////
 
 DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(const Points &p) {
+    if (p.size() < 3u) // GCOVR_EXCL_BR_LINE
+        return {};
+
     PositionVector vecToEarth = algorithm_->Run(p); // s_C
 
     Vec3 shapeMatrixFactor = algorithm_->getPrincipleAxes().cwiseInverse();
@@ -76,11 +79,11 @@ DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(c
         decimal residual = homogeneous.transpose() * transformedConicLocusMatrix * homogeneous;
         pointVariance += residual * residual;
     }
-    pointVariance /= p.size();
+    pointVariance /= p.size(); // GCOVR_EXCL_BR_LINE
 
     Mat3 outCovarianceInverse = Mat3::Zero();
 
-    for (size_t i = 0; i < p.size(); i++) {
+    for (size_t i = 0; i < p.size(); i++) { // GCOVR_EXCL_BR_LINE
         // p[i] = u_i
         // x_i
         const Vec3 &point = algorithm_->getCamera().PixelToImageCoordinates(p[i]);

--- a/src/distance/distance.cpp
+++ b/src/distance/distance.cpp
@@ -56,19 +56,23 @@ PositionVector SpheroidDistanceDeterminationAlgorithm::Run(const Points &p) {
 DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(const Points &p) {
     PositionVector vecToEarth = algorithm_->Run(p); // s_C
 
-    const Vec3 shapeMatrixFactor = algorithm_->getPrincipleAxes().cwiseInverse();
-    const Mat3 shapeMatrix = shapeMatrixFactor.cwiseProduct(shapeMatrixFactor).asDiagonal();
+    Vec3 shapeMatrixFactor = algorithm_->getPrincipleAxes().cwiseInverse();
+    Mat3 shapeMatrix = shapeMatrixFactor.cwiseProduct(shapeMatrixFactor).asDiagonal();
     
     // A_C
-    const Mat3 transformedShapeMatrix = algorithm_->getTPC() * shapeMatrix * algorithm_->getTPC().transpose();
+    Mat3 transformedShapeMatrix = algorithm_->getTPC() * shapeMatrix * algorithm_->getTPC().transpose();
 
     // M_C
-    const Mat3 transformedConicLocusMatrix = transformedShapeMatrix * (vecToEarth * vecToEarth.transpose()) * transformedShapeMatrix - (vecToEarth.transpose() * transformedShapeMatrix * vecToEarth - 1.0) * transformedShapeMatrix;
+    Mat3 transformedConicLocusMatrix = transformedShapeMatrix * (vecToEarth * vecToEarth.transpose()) * transformedShapeMatrix - (vecToEarth.transpose() * transformedShapeMatrix * vecToEarth - 1.0) * transformedShapeMatrix;
 
-    // sigma_{u_i}
-    const decimal pixelStandardDeviation = 0.0; // TODO
-    // d_x
-    const decimal focalLengthPixels = 0.0; // TODO
+    // sigma_{x_i}
+    decimal pointVariance = 0.0;
+    for (const auto &point : p) {
+        Vec3 homogeneous = point.homogeneous();
+        decimal residual = homogeneous.transpose() * transformedConicLocusMatrix * homogeneous;
+        pointVariance += residual * residual;
+    }
+    pointVariance /= p.size();
 
     Mat3 outCovarianceInverse = Mat3::Zero();
 
@@ -77,15 +81,11 @@ DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(c
         // x_i
         const Vec3 &point = algorithm_->getCamera().PixelToImageCoordinates(p[i]);
 
-        // we can also calculate this by using the image plane points, we dont
-        // need to necessarily get it from the pixel coordinates
-        const decimal pointVariance = (pixelStandardDeviation / focalLengthPixels);
-        
         // see Exercise 8.6
-        const Mat3 pointCovariance = Vec3(pointVariance, pointVariance, 0).asDiagonal();
+        Mat3 pointCovariance = Vec3(pointVariance, pointVariance, 0).asDiagonal();
 
-        const decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix * pointCovariance * transformedConicLocusMatrix * point;
-        const Mat3 jacobian = 2.0 * vecToEarth.transpose() * ((point.transpose() * transformedShapeMatrix * point) * transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * transformedShapeMatrix);
+        decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix * pointCovariance * transformedConicLocusMatrix * point;
+        Mat3 jacobian = 2.0 * vecToEarth.transpose() * ((point.transpose() * transformedShapeMatrix * point) * transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * transformedShapeMatrix);
 
         outCovarianceInverse += (jacobian.transpose() * jacobian) / residualVariance;
     }

--- a/src/distance/distance.cpp
+++ b/src/distance/distance.cpp
@@ -60,10 +60,14 @@ DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(c
     Mat3 shapeMatrix = shapeMatrixFactor.cwiseProduct(shapeMatrixFactor).asDiagonal();
     
     // A_C
-    Mat3 transformedShapeMatrix = algorithm_->getTPC() * shapeMatrix * algorithm_->getTPC().transpose();
+    Mat3 transformedShapeMatrix = algorithm_->getTPC() * 
+        shapeMatrix * algorithm_->getTPC().transpose();
 
     // M_C
-    Mat3 transformedConicLocusMatrix = transformedShapeMatrix * (vecToEarth * vecToEarth.transpose()) * transformedShapeMatrix - (vecToEarth.transpose() * transformedShapeMatrix * vecToEarth - 1.0) * transformedShapeMatrix;
+    Mat3 transformedConicLocusMatrix = transformedShapeMatrix * 
+            (vecToEarth * vecToEarth.transpose()) * transformedShapeMatrix - 
+            (vecToEarth.transpose() * transformedShapeMatrix * vecToEarth - 1.0) * 
+            transformedShapeMatrix;
 
     // sigma_{x_i}
     decimal pointVariance = 0.0;
@@ -84,8 +88,12 @@ DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(c
         // see Exercise 8.6
         Mat3 pointCovariance = Vec3(pointVariance, pointVariance, 0).asDiagonal();
 
-        decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix * pointCovariance * transformedConicLocusMatrix * point;
-        Mat3 jacobian = 2.0 * vecToEarth.transpose() * ((point.transpose() * transformedShapeMatrix * point) * transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * transformedShapeMatrix);
+        decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix *
+            pointCovariance * transformedConicLocusMatrix * point;
+        Mat3 jacobian = 2.0 * vecToEarth.transpose() * 
+            ((point.transpose() * transformedShapeMatrix * point) * 
+             transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * 
+             transformedShapeMatrix);
 
         outCovarianceInverse += (jacobian.transpose() * jacobian) / residualVariance;
     }

--- a/src/distance/distance.cpp
+++ b/src/distance/distance.cpp
@@ -90,12 +90,13 @@ DistanceAndCovariance SpheroidDistanceAndCovarianceDeterminationAlgorithm::Run(c
 
         decimal residualVariance = 4.0 * point.transpose() * transformedConicLocusMatrix *
             pointCovariance * transformedConicLocusMatrix * point;
-        Mat3 jacobian = 2.0 * vecToEarth.transpose() * 
+
+        auto H = 2.0 * vecToEarth.transpose() * 
             ((point.transpose() * transformedShapeMatrix * point) * 
              transformedShapeMatrix - transformedShapeMatrix * point * point.transpose() * 
              transformedShapeMatrix);
 
-        outCovarianceInverse += (jacobian.transpose() * jacobian) / residualVariance;
+        outCovarianceInverse += (H.transpose() * H) / residualVariance;
     }
 
     return {

--- a/src/distance/distance.hpp
+++ b/src/distance/distance.hpp
@@ -94,6 +94,24 @@ class SpheroidDistanceDeterminationAlgorithm : public DistanceDeterminationAlgor
      */
     PositionVector Run(const Points &p) override;
 
+    const Camera &getCamera() const {
+        return cam_;
+    }
+
+    /**
+     * Returns the global to local transformation matrix.
+     */
+    const Mat3 &getTPC() const {
+        return TPC_;
+    }
+
+    /**
+     * Returns the principle axes of the target planet.
+     */
+    const Vec3 &getPrincipleAxes() const {
+        return principleAxes_;
+    }
+
  protected:
    /**
     * cam_ field instance describes the camera settings used for the photo taken
@@ -117,6 +135,22 @@ class SpheroidDistanceDeterminationAlgorithm : public DistanceDeterminationAlgor
 
     /** Injected regression: data (Nx4) -> 3-vector; if empty, TLS is used. */
     RegressionFunc regression_;
+};
+
+class SpheroidDistanceAndCovarianceDeterminationAlgorithm : public FunctionStage<Points, DistanceAndCovariance> {
+ public:
+
+    SpheroidDistanceAndCovarianceDeterminationAlgorithm(
+        std::unique_ptr<SpheroidDistanceDeterminationAlgorithm> algorithm
+    ) : algorithm_(std::move(algorithm)) {};
+
+    virtual ~SpheroidDistanceAndCovarianceDeterminationAlgorithm() {}
+
+    DistanceAndCovariance Run(const Points &p) override;
+
+ protected:
+    std::unique_ptr<SpheroidDistanceDeterminationAlgorithm> algorithm_;
+
 };
 
 /**

--- a/src/distance/distance.hpp
+++ b/src/distance/distance.hpp
@@ -137,18 +137,37 @@ class SpheroidDistanceDeterminationAlgorithm : public DistanceDeterminationAlgor
     RegressionFunc regression_;
 };
 
+/**
+ * This class represents a wrapper around the SpheroidDistanceDeterminationAlgorithm that
+ * additionally calculates a covariance matrix for the calculated point.
+ */
 class SpheroidDistanceAndCovarianceDeterminationAlgorithm : public FunctionStage<Points, DistanceAndCovariance> {
  public:
 
+    /**
+     * Creates a SpheroidDistanceAndCovarianceDeterminationAlgorithm using a pointer to a given
+     * SpheroidDistanceDeterminationAlgorithm.
+     *
+     * @param algorithm The SpheroidDistanceDeterminationAlgorithm to use when calculating
+     * covariance.
+     */
     SpheroidDistanceAndCovarianceDeterminationAlgorithm(
         std::unique_ptr<SpheroidDistanceDeterminationAlgorithm> algorithm
     ) : algorithm_(std::move(algorithm)) {};
-
     virtual ~SpheroidDistanceAndCovarianceDeterminationAlgorithm() {}
 
+    /**
+     * Using a set of points on the horizon of a celestial body, obtains a position of the planet
+     * relative to the camera, and then calculates the covariance of the estimate.
+     *
+     * @param p The list of points on the horizon to use.
+     * @return The estimated position of the planet relative to the camera and the covariance of the
+     * estimate.
+     */
     DistanceAndCovariance Run(const Points &p) override;
 
  protected:
+    /** The SpheroidDistanceDeterminationAlgorithm to use when determining position of the planet */
     std::unique_ptr<SpheroidDistanceDeterminationAlgorithm> algorithm_;
 
 };

--- a/test/distance/distance-test/covariance-test.cpp
+++ b/test/distance/distance-test/covariance-test.cpp
@@ -10,7 +10,6 @@
 #include "common/decimal.hpp"
 #include "common/spatial/camera.hpp"
 #include "common/spatial/attitude-utils.hpp"
-#incl
 
 using found::Camera;
 using found::Vec3;
@@ -20,7 +19,7 @@ using found::Points;
 using found::PositionVector;
 using found::SpheroidDistanceDeterminationAlgorithm;
 using found::SpheroidDistanceAndCovarianceDeterminationAlgorithm;
-using found::Quarternion;
+using found::Quaternion;
 
 
 // The equatorial radius of Earth (m)
@@ -34,12 +33,7 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
     // define principle axes of the spheroid
     Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
     // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
-    Quaternion relativeOrientation = found::AttitudeUtils::CalculateRelativeOrientation(
-        Vec3(1, 0, 0), // camera is looking in the positive x direction
-        Vec3(0, 1, 0), // camera's up direction is in the positive y direction
-        Vec3(0, 0, 1)  // camera's right direction is in the positive z direction
-    );
-    
+    Quaternion relativeOrientation = Quaternion::Identity();
     // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
     SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
     
@@ -61,3 +55,40 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
         // I'm pretty sure this is the right way to check for symmetry, 
         //but if not, we can also check that the off-diagonal elements are equal
 }
+
+TEST(SpheroidDistanceAndCovarianceAlgorithm, CovarianceIsPositiveDefinite) {
+    // create a camera
+    Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    // define principle axes of the spheroid
+    Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
+    // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
+    Quaternion relativeOrientation = found::Quarternion::Identity();
+    // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
+    SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
+    
+    // create a spheriod distance and covariance determination algorithm class
+    SpheroidDistanceAndCovarianceDeterminationAlgorithm covarianceAlgorithm(std::make_unique<SpheroidDistanceDeterminationAlgorithm>(std::move(distanceAlgorithm)));
+    
+    // create a set of points on the horizon of a celestial body
+    Points points = {
+        Vec2(758, 637),
+        Vec2(845, 182),
+        Vec2(928, 304)
+    };
+
+    // run the algorithm on the set of points
+    auto result = covarianceAlgorithm.Run(points);
+
+    // test that the covariance is positive definite
+    // extract the eigenvalues of the covariance matrix
+    Eigen::EigenSolver<Mat3> es(result.covariance);
+    auto eigenvalues = es.eigenvalues();
+    // check all eigenvalues are non-negative
+    for (int i = 0; i < eigenvalues.size(); i++) {
+        EXPECT_GE(eigenvalues(i).real(), 0);
+    }
+}
+
+// test that the covariance blows up when the arc is small
+
+// what parts of the algorithm should be tested independently?

--- a/test/distance/distance-test/covariance-test.cpp
+++ b/test/distance/distance-test/covariance-test.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <memory>
 
+#include <Eigen/Eigenvalues>
+
 // Test for SpheroidDistanceAndCovarianceAlgorithm
 #include "distance/distance.hpp"
 #include "common/decimal.hpp"
@@ -93,4 +95,54 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, CovarianceIsPositiveDefinite) {
     for (int i = 0; i < eigenvalues.size(); i++) {
         EXPECT_GE(eigenvalues(i).real(), 0);
     }
+}
+
+TEST(SpheroidDistanceAndCovarianceAlgorithm, NotEnoughPoints) {
+    // create a camera
+    Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    
+    // define principle axes of the spheroid
+    Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
+    
+    // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
+    Quaternion relativeOrientation = found::Quaternion::Identity();
+    
+    // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
+    SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
+    
+    // create a spheriod distance and covariance determination algorithm class
+    SpheroidDistanceAndCovarianceDeterminationAlgorithm covarianceAlgorithm(std::make_unique<SpheroidDistanceDeterminationAlgorithm>(std::move(distanceAlgorithm)));
+    
+    // create a set of points that is too small (under 3)
+    Points points = {
+        Vec2(758, 637),
+    };
+    
+    auto result = covarianceAlgorithm.Run(points);
+    EXPECT_EQ(result.distance, Vec3(0, 0, 0));
+    EXPECT_EQ(result.covariance, Mat3());
+}
+
+TEST(SpheroidDistanceAndCovarianceAlgorithm, OopsNoPoints) {
+    // create a camera
+    Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    
+    // define principle axes of the spheroid
+    Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
+    
+    // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
+    Quaternion relativeOrientation = found::Quaternion::Identity();
+    
+    // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
+    SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
+    
+    // create a spheriod distance and covariance determination algorithm class
+    SpheroidDistanceAndCovarianceDeterminationAlgorithm covarianceAlgorithm(std::make_unique<SpheroidDistanceDeterminationAlgorithm>(std::move(distanceAlgorithm)));
+    
+    // create a set of nothing
+    Points points = {};
+    
+    auto result = covarianceAlgorithm.Run(points);
+    EXPECT_EQ(result.distance, Vec3(0, 0, 0));
+    EXPECT_EQ(result.covariance, Mat3());
 }

--- a/test/distance/distance-test/covariance-test.cpp
+++ b/test/distance/distance-test/covariance-test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <string>
+#include <memory>
+
+// Test for SpheroidDistanceAndCovarianceAlgorithm
+#include "distance/distance.hpp"
+#include "common/decimal.hpp"
+#include "common/spatial/camera.hpp"
+#include "common/spatial/attitude-utils.hpp"
+#incl
+
+using found::Camera;
+using found::Vec3;
+using found::Vec2;
+using found::Mat3;
+using found::Points;
+using found::PositionVector;
+using found::SpheroidDistanceDeterminationAlgorithm;
+using found::SpheroidDistanceAndCovarianceDeterminationAlgorithm;
+using found::Quarternion;
+
+
+// The equatorial radius of Earth (m)
+#define RADIUS_OF_EARTH_A (DECIMAL(6378.1366))
+// The polar radius of Earth (m)
+#define RADIUS_OF_EARTH_C (DECIMAL(6356.7519))
+
+TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
+    // create a camera
+    Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    // define principle axes of the spheroid
+    Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
+    // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
+    Quaternion relativeOrientation = found::AttitudeUtils::CalculateRelativeOrientation(
+        Vec3(1, 0, 0), // camera is looking in the positive x direction
+        Vec3(0, 1, 0), // camera's up direction is in the positive y direction
+        Vec3(0, 0, 1)  // camera's right direction is in the positive z direction
+    );
+    
+    // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
+    SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
+    
+    // create a spheriod distance and covariance determination algorithm class
+    SpheroidDistanceAndCovarianceDeterminationAlgorithm covarianceAlgorithm(std::make_unique<SpheroidDistanceDeterminationAlgorithm>(std::move(distanceAlgorithm)));
+    
+    // create a set of points on the horizon of a celestial body
+    Points points = {
+        Vec2(1000, 1500),
+        Vec2(2000, 1500),
+        Vec2(3000, 1500)
+    };
+
+    // run the algorithm on the set of points
+    auto result = covarianceAlgorithm.Run(points);
+
+    // test that the covariance is symmetric
+    EXPECT_TRUE(result.covariance.isApprox(result.covariance.transpose()));
+}

--- a/test/distance/distance-test/covariance-test.cpp
+++ b/test/distance/distance-test/covariance-test.cpp
@@ -58,4 +58,6 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
 
     // test that the covariance is symmetric
     EXPECT_TRUE(result.covariance.isApprox(result.covariance.transpose()));
+        // I'm pretty sure this is the right way to check for symmetry, 
+        //but if not, we can also check that the off-diagonal elements are equal
 }

--- a/test/distance/distance-test/covariance-test.cpp
+++ b/test/distance/distance-test/covariance-test.cpp
@@ -30,10 +30,13 @@ using found::Quaternion;
 TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
     // create a camera
     Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    
     // define principle axes of the spheroid
     Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
-    // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
+
+    // calculate the orientation of the camera relative to the spheroid
     Quaternion relativeOrientation = Quaternion::Identity();
+
     // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
     SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
     
@@ -42,9 +45,9 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
     
     // create a set of points on the horizon of a celestial body
     Points points = {
-        Vec2(1000, 1500),
-        Vec2(2000, 1500),
-        Vec2(3000, 1500)
+        Vec2(837, 924),
+        Vec2(878, 734),
+        Vec2(960, 675)
     };
 
     // run the algorithm on the set of points
@@ -59,10 +62,13 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, SymmetricCovarianceOutput) {
 TEST(SpheroidDistanceAndCovarianceAlgorithm, CovarianceIsPositiveDefinite) {
     // create a camera
     Camera cam(DECIMAL(0.005), 4000, 3000, DECIMAL(2000), DECIMAL(1500), DECIMAL(1.12e-6), DECIMAL(1.12e-6));
+    
     // define principle axes of the spheroid
     Vec3 principleAxes(RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_A, RADIUS_OF_EARTH_C);
+    
     // calculate the orientation of the camera relative to the spheroid - thi is a matrix?
-    Quaternion relativeOrientation = found::Quarternion::Identity();
+    Quaternion relativeOrientation = found::Quaternion::Identity();
+    
     // create a spheriod distance determination algorithm class to pass into the covariance algorithm class
     SpheroidDistanceDeterminationAlgorithm distanceAlgorithm(std::move(cam), principleAxes, relativeOrientation, relativeOrientation);
     
@@ -88,7 +94,3 @@ TEST(SpheroidDistanceAndCovarianceAlgorithm, CovarianceIsPositiveDefinite) {
         EXPECT_GE(eigenvalues(i).real(), 0);
     }
 }
-
-// test that the covariance blows up when the arc is small
-
-// what parts of the algorithm should be tested independently?


### PR DESCRIPTION
This adds a new function stage (`SpheroidDistanceAndCovarianceDeterminationAlgorithm`) that wraps around the `SpheroidDistanceDeterminationAlgorithm` to additionally calculate the covariance of the estimated position. Importantly this is not a `DistanceDeterminationAlgorithm`, instead returning a `DistanceAndCovariance` struct which contains both a estimate and it's covariance. This is a break from the pipeline model but is the best compromise for right now.