### PR TITLE
Tool: clang-format config and editor integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+---
+BasedOnStyle: Google
+
+IndentWidth: 4
+AccessModifierOffset: -3
+ColumnLimit: 120
+
+PointerAlignment: Right
+DerivePointerAlignment: false
+
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+
+BreakStringLiterals: false
+ReflowComments: false
+
+SpaceAfterTemplateKeyword: false
+
+SortIncludes: Never
+IncludeBlocks: Preserve
+
+AlignConsecutiveMacros: Consecutive
+
+BinPackParameters: false
+BinPackArguments: false
+...

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,18 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "twxs.cmake"
-      ]
+        "twxs.cmake",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "[cpp]": {
+          "editor.defaultFormatter": "ms-vscode.cpptools",
+          "editor.formatOnSave": true,
+          "editor.formatOnSaveMode": "modifications"
+        },
+        "C_Cpp.formatting": "clangFormat",
+        "C_Cpp.clang_format_style": "file"
+      }
     }
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ case "$OS" in
         fi
         INSTALL="$PM install -y"
         # List of packages to install
-        PACKAGES="git g++ make cmake wget tar python3 python3-pip pipx graphviz valgrind"
+        PACKAGES="git g++ make cmake wget tar python3 python3-pip pipx graphviz valgrind clang-format"
         ;;
     Darwin*)
         # Check if Homebrew is installed; install it if not
@@ -69,7 +69,7 @@ case "$OS" in
         fi
         INSTALL="brew install"
         # List of packages to install
-        PACKAGES="git gcc make cmake wget gnu-tar python pipx graphviz"
+        PACKAGES="git gcc make cmake wget gnu-tar python pipx graphviz clang-format"
         ;;
     *)
         echo "Unknown Operating System $OS"


### PR DESCRIPTION
- Add `.clang-format` (Google base, 4-space indent, 120 col, custom tweaks) to define the project's C++ style
- Install `clang-format` via `install.sh` on Linux (apt/dnf) and macOS (brew)
- Add the `ms-vscode.cpptools` extension to the devcontainer wired to use clang-format with the style file
- Enable VSCode settings `editor.formatOnSave` with `formatOnSaveMode: "modifications"`, which will automatically format the file when saved, but will only touch changed lines

# Artifacts for PR #74 (DO NOT CHANGE)
- [Coverage Artifact](https://uwcubesat.github.io/found/74/merge/coverage)
- [Doxygen Artifact](https://uwcubesat.github.io/found/74/merge/doxygen)